### PR TITLE
Make it work for Ubuntu

### DIFF
--- a/modules/FileTreeView.js
+++ b/modules/FileTreeView.js
@@ -1002,6 +1002,9 @@ define(function (require, exports, module) {
 	onDirClicked = function ($elem) {
 		var id = $elem.attr("id");
 		var entity = _getEntityWithId(id);
+        
+        var localPath = PathManager.completionLocalPath(getPathArray(entity));
+         _makeBaseDirectoryIfIsNotExists(localPath)                   
 		
 		if ($elem.hasClass("loaded")) {
 			_toggleDir(entity);


### PR DESCRIPTION
mkdir cannot be done only when the file is open. It must be done each time we dive deeper in directories.
Linux doesn't seem to be able to create a directory from a brand new full path :

if /root exists 
and 
/root/sub1 doesn't exists
and 
/root/sub1/sub2 doesn't exists 
then 
mkdir /root/sub1/sub2 will fail