### PR TITLE
Allow enter key to submit password for decryption

### DIFF
--- a/modules/Notify.js
+++ b/modules/Notify.js
@@ -63,10 +63,11 @@ define(function (require, exports, module) {
 		
 		var $notify = $("#synapse-decrypt-password-notify"),
 				$password = $("#synapse-decrypt-password-input", $notify),
-				$btn1 = $("#synapse-decrypt-password-btn1", $notify),
+				$form = $("#synapse-decrypt-password-form", $notify),
 				$validMessage = $("p.validateMessage", $notify);
 		
-		$btn1.on("click", function (e) {
+		$form.on("submit", function (e) {
+            e.preventDefault();
 			var password = $password.val();
 			if (password === "") {
 				$password.addClass("invalid");
@@ -90,7 +91,7 @@ define(function (require, exports, module) {
 					$validMessage.html("");
 					close()
 					.then(function () {
-						$btn1.off("click");
+						$form.off("submit");
 						d.resolve();
 					});
 				}

--- a/ui/notify/decryptPassword.html
+++ b/ui/notify/decryptPassword.html
@@ -1,8 +1,10 @@
 <div class="notify-message">{{{Strings.SYNAPSE_DECRYPT_PASSWORD_MESSAGE}}}</div>
 <div class="notify-content">
 	<div class="input-append">
-		<input type="password" id="synapse-decrypt-password-input">
-		<button class="btn primary" id="synapse-decrypt-password-btn1" type="button">OK</button>
+        <form id="synapse-decrypt-password-form">
+            <input type="password" id="synapse-decrypt-password-input" autofocus>
+            <input class="btn primary" type="submit" value="OK">
+        </form>
 	</div>
 	<p class="validateMessage"></p>
 </div>


### PR DESCRIPTION
By changing the password entry for decryption to an HTML form instead of just an input, the enter key can submit the password as well as the button, allowing for easier and faster access.